### PR TITLE
Improve SEO meta on key pages

### DIFF
--- a/frontend/pages/about.vue
+++ b/frontend/pages/about.vue
@@ -13,5 +13,24 @@
 </template>
 
 <script setup>
-const {t} = useI18n()
+const { t } = useI18n()
+
+useHead({
+  title: 'Evente - Sobre nosotros',
+  meta: [
+    {
+      name: 'description',
+      content:
+        'Descubre la misión y valores de Evente. Conectamos a organizadores y asistentes en Canarias.',
+    },
+    { property: 'og:title', content: 'Evente - Sobre nosotros' },
+    {
+      property: 'og:description',
+      content:
+        'Descubre la misión y valores de Evente. Conectamos a organizadores y asistentes en Canarias.',
+    },
+    { property: 'og:url', content: 'https://evente.es/about' },
+  ],
+  link: [{ rel: 'canonical', href: 'https://evente.es/about' }],
+})
 </script>

--- a/frontend/pages/articles/[id].vue
+++ b/frontend/pages/articles/[id].vue
@@ -78,6 +78,31 @@ const { article } = storeToRefs(articleStore)
 
 const articleId = route.params.id
 
+useHead(() => ({
+  title: article.value?.title || 'Evente',
+  meta: [
+    {
+      name: 'description',
+      content:
+        article.value?.content
+          ? article.value.content.replace(/<[^>]*>?/gm, '').slice(0, 155)
+          : '',
+    },
+    { property: 'og:title', content: article.value?.title || 'Evente' },
+    {
+      property: 'og:description',
+      content:
+        article.value?.content
+          ? article.value.content.replace(/<[^>]*>?/gm, '').slice(0, 155)
+          : '',
+    },
+    { property: 'og:image', content: article.value?.coverImage || '/defaultImg.png' },
+    { property: 'og:url', content: `https://evente.es/articles/${articleId}` },
+    { property: 'og:type', content: 'article' },
+  ],
+  link: [{ rel: 'canonical', href: `https://evente.es/articles/${articleId}` }],
+}))
+
 
 onMounted(
   async () => (article.value = await articleStore.fetchArticleById(articleId))

--- a/frontend/pages/contact.vue
+++ b/frontend/pages/contact.vue
@@ -115,6 +115,25 @@ const {toast} = useToast()
 const {userData} = useUserStore()
 const {t} = useI18n()
 
+useHead({
+  title: 'Evente - Contacto',
+  meta: [
+    {
+      name: 'description',
+      content:
+        'Póngase en contacto con el equipo de Evente para cualquier duda o consulta.',
+    },
+    { property: 'og:title', content: 'Evente - Contacto' },
+    {
+      property: 'og:description',
+      content:
+        'Póngase en contacto con el equipo de Evente para cualquier duda o consulta.',
+    },
+    { property: 'og:url', content: 'https://evente.es/contact' },
+  ],
+  link: [{ rel: 'canonical', href: 'https://evente.es/contact' }],
+})
+
 
 const contactMail = ref({
   firstName: '',

--- a/frontend/pages/events/index.vue
+++ b/frontend/pages/events/index.vue
@@ -46,6 +46,25 @@
 
 <script setup>
 import { storeToRefs } from 'pinia'
+
+useHead({
+  title: 'Eventos - Evente',
+  meta: [
+    {
+      name: 'description',
+      content:
+        'Explora todos los eventos publicados en Evente y encuentra actividades cercanas a ti.',
+    },
+    { property: 'og:title', content: 'Eventos - Evente' },
+    {
+      property: 'og:description',
+      content:
+        'Explora todos los eventos publicados en Evente y encuentra actividades cercanas a ti.',
+    },
+    { property: 'og:url', content: 'https://evente.es/events' },
+  ],
+  link: [{ rel: 'canonical', href: 'https://evente.es/events' }],
+})
 const userStore = useUserStore()
 const eventStore = useEventStore()
 const paymentStore = usePaymentStore()


### PR DESCRIPTION
## Summary
- add meta tags and canonical link to about page
- add SEO metadata to contact page
- improve events listing page SEO
- add dynamic SEO meta to article pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687eaee1ca208320b5b5b47f65fe2179